### PR TITLE
update: docker compose cli v2 の変更に対応

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   mysql:
     platform: linux/x86_64 # M1チップ対応のため追記


### PR DESCRIPTION
- version の指定不要
- compose.yaml が推奨となった